### PR TITLE
Submit Game /post to real API

### DIFF
--- a/src/pages/Create.vue
+++ b/src/pages/Create.vue
@@ -11,17 +11,20 @@ export default {
   data: () => ({
     GAME_SCHEMA,
     GAME_INFO_SCHEMA,
+    infoUrl: null,
   }),
   methods: {
     handleGameInfo(formModels) {
+      this.infoUrl = formModels.url
       this.$store.dispatch(GAME_INFO_RETRIEVE_ACTION, formModels.url)
     },
     handleGameSubmit(formModels) {
-      this.$store.dispatch(NEW_GAME_SUBMIT_ACTION, formModels)
+      this.$store.dispatch(NEW_GAME_SUBMIT_ACTION, { ...formModels, url: this.infoUrl })
     },
     resetInfoForm() {
       this.$refs.infoForm.$refs.dynamicForm.reset()
       this.$store.dispatch(GAME_INFO_RESET_ACTION)
+      this.infoUrl = null
     },
   },
   computed: {

--- a/src/services/fieldDescriptors.js
+++ b/src/services/fieldDescriptors.js
@@ -198,7 +198,7 @@ const gameUrl = {
 
 const gameName = {
   component: 'q-input',
-  model: 'gameName',
+  model: 'name',
   fieldOptions: {
     class: [],
     on: { input: true },
@@ -242,7 +242,7 @@ const gameTags = {
 
 const gameShortDescription = {
   component: 'q-input',
-  model: 'shortDescription',
+  model: 'short_description',
   fieldOptions: {
     class: [],
     on: { input: true },

--- a/src/services/messages.js
+++ b/src/services/messages.js
@@ -16,6 +16,11 @@ export const messages = {
     color: 'negative',
     type: 'negative',
   },
+  failGameSubmit: message => ({
+    message: `${message || 'Oh noes! There was an issue trying to submit your game.'}`,
+    color: 'negative',
+    type: 'negative',
+  }),
   invalidLogin: {
     message: 'Failed to login with the provided email and password.',
     color: 'negative',

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -1,3 +1,5 @@
+import { Loading } from 'quasar'
+
 export const mockGameInfoHttpRequest = async url => {
   // mocking the api request until the endpoint is implemented
   return new Promise(resolve => {
@@ -11,6 +13,20 @@ export const mockGameInfoHttpRequest = async url => {
       resolve({ data })
     }, 1000)
   })
+}
+
+export const asyncRequestWithLoader = async (
+  { loadingMessage, tryCb, catchCb, finallyCb }
+  = { loadingMessage: null, tryCb: null, catchCb: null, finallyCb: null }) => {
+  loadingMessage ? Loading.show({ message: loadingMessage }) : null
+  try {
+    await tryCb()
+  } catch(error) {
+    catchCb ? await catchCb(error) : null
+  } finally {
+    finallyCb ? await finallyCb() : null
+    loadingMessage ? Loading.hide() : null
+  }
 }
 
 export const errorMessageFromApiResponse = error => {

--- a/src/store.js
+++ b/src/store.js
@@ -42,9 +42,6 @@ export default new Vuex.Store({
     },
     [USER_PROFILE_UPDATED_ACTION]({ commit }) {
       commit(SET_USER_MUTATION, auth.profile)
-    async [NEW_GAME_SUBMIT_ACTION](context, formModels) {
-      await router.push({ path: '/' })
-      notify(messages.gameSubmitted(formModels.gameName))
     },
     [GAME_INFO_RESET_ACTION]({ commit }) {
       commit(RESET_INFO_MUTATION, null)
@@ -56,6 +53,20 @@ export default new Vuex.Store({
           const gameInfoResponse = await mockGameInfoHttpRequest(url)
           commit(SET_INFO_MUTATION, gameInfoResponse.data)
           notify(messages.dataLoadedForGame(url))
+        },
+      })
+    },
+    async [NEW_GAME_SUBMIT_ACTION](context, formModels) {
+      await asyncRequestWithLoader({
+        loadingMessage: 'Submitting new game...',
+        tryCb: async () => {
+          await Vue.prototype.$axios.post('/games', formModels)
+          router.push({ path: '/' })
+          notify(messages.gameSubmitted(formModels.name))
+        },
+        catchCb: async error => {
+          const errorMessage = errorMessageFromApiResponse(error)
+          notify(messages.failGameSubmit(errorMessage))
         },
       })
     },

--- a/test/cypress/integration/createGame.spec.js
+++ b/test/cypress/integration/createGame.spec.js
@@ -1,3 +1,5 @@
+import { uniqueGameUrl } from '../util'
+
 describe('Create Game', function () {
   beforeEach(() => {
     cy.setupAlgoliaStub()
@@ -9,13 +11,33 @@ describe('Create Game', function () {
     cy.createNewGameRequest()
   })
 
+  it('should only submit new games for urls that have not already been submitted', () => {
+    const url = uniqueGameUrl()
+    cy.goCreateGame()
+    cy.createNewGameRequest({
+      url,
+      name: 'GameOne',
+      shortDescription: 'Game One Description',
+    })
+    cy.verifyHomepage()
+    cy.goCreateGame()
+
+    cy.typeIntoFormField('URL *', url)
+    cy.contains('GET INFO').click()
+
+    cy.typeIntoFormField('Name *', 'DuplicateUrlGame')
+    cy.typeIntoFormField('Short Description *', 'DuplicateUrlGame Description')
+    cy.contains('Save').click()
+    cy.contains('The given data was invalid. The url has already been taken.').should('be.visible')
+  })
+
   it('should require a valid url before allowing submit', () => {
     cy.goCreateGame()
     cy.typeIntoFormField('URL *', 'invalidUrl')
     cy.contains('GET INFO').click()
 
     cy.expectHTML5ValidationMessage('url', 'Please enter a URL.')
-    cy.typeIntoFormField('URL *', 'https://www.google.com')
+    cy.typeIntoFormField('URL *', uniqueGameUrl())
     cy.contains('GET INFO').click()
 
     cy.typeIntoFormField('Name *', 'TestGame')
@@ -27,7 +49,7 @@ describe('Create Game', function () {
 
   it('should require a name before allowing submit', () => {
     cy.goCreateGame()
-    cy.typeIntoFormField('URL *', 'https://www.google.com')
+    cy.typeIntoFormField('URL *', uniqueGameUrl())
     cy.contains('GET INFO').click()
     cy.typeIntoFormField('Short Description *', 'a big long description here and some more text.')
     cy.contains('Save').click()
@@ -42,7 +64,7 @@ describe('Create Game', function () {
 
   it('should require a short description before allowing submit', () => {
     cy.goCreateGame()
-    cy.typeIntoFormField('URL *', 'https://www.google.com')
+    cy.typeIntoFormField('URL *', uniqueGameUrl())
     cy.contains('GET INFO').click()
     cy.typeIntoFormField('Name *', 'TestGame')
     cy.contains('Save').click()

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -23,7 +23,7 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
-import { mockAlgolia } from '../util.js'
+import {mockAlgolia, uniqueGameName, uniqueGameUrl} from '../util.js'
 
 Cypress.Commands.add('setupAlgoliaStub', () => {
   mockAlgolia()
@@ -92,15 +92,18 @@ Cypress.Commands.add('logout', (name = null) => {
 })
 
 Cypress.Commands.add('createNewGameRequest', ({ url, name, shortDescription } = { url: null, name: null, shortDescription: null }) => {
-  const gameUrl = url ? url : 'https://www.google.com'
+  const uniqueName = name ? name : uniqueGameName()
+  const gameUrl = url ? url : uniqueGameUrl(uniqueName)
+  const description = shortDescription ? shortDescription : `a big long description here about this game, ${uniqueName}, and some more text.`
+
   cy.typeIntoFormField('URL *', gameUrl)
   cy.contains('GET INFO').click()
 
   cy.contains('Stand by. Loading game data...').should('be.visible')
   cy.contains(`Data loaded for ${gameUrl}`)
 
-  cy.typeIntoFormField('Name *', name ? name : 'TestGame')
-  cy.typeIntoFormField('Short Description *', shortDescription ? shortDescription : 'a big long description here and some more text.')
+  cy.typeIntoFormField('Name *', uniqueName)
+  cy.typeIntoFormField('Short Description *', description)
   cy.contains('Save').click()
   cy.verifyHomepage()
   cy.contains('Success!').should('be.visible')

--- a/test/cypress/util.js
+++ b/test/cypress/util.js
@@ -14,3 +14,11 @@ export function uniqueUser ({ name, email, password, confirmPassword } = { name:
     confirmPassword: confirmPassword ? confirmPassword : 'pass1234',
   }
 }
+
+export function uniqueGameName (specificDateNow) {
+  return 'game-' + (specificDateNow ? specificDateNow : Date.now().toString())
+}
+
+export function uniqueGameUrl (url) {
+  return `https://www.${url ? url : uniqueGameName()}.com`
+}


### PR DESCRIPTION
This completes the FE being able to POST a new game submission to the `/games` endpoint.  While it currently does not do all that we want via the GetInfo button (and also doesn't yet do anything extra like make use of the homepage image, as we would like) - this does provide the minimum functionality to be working and it should fix #12 .