### PR TITLE
Remove hard dependency on Algolia integration and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,0 @@
-# This is your .env file
-# The data added here will be propagated to the client
-# example:
-# PORT=8080
-ALGOLIA_APP_ID=
-ALGOLIA_KEY=
-ALGOLIA_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+API_BASE_URL=https://dev-api.pbbg.com

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,10 @@ jobs:
   cypress-run:
     runs-on: ubuntu-16.04
     env:
-      ALGOLIA_APP_ID: TF6EHQUG2K
-      ALGOLIA_KEY: 3ab2216a85ee66f3ecd52c90c1f690fc
+      ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+      ALGOLIA_KEY: ${{ secrets.ALGOLIA_KEY }}
+      # This allows self-signed ssl certs to work so UATs run against https
+      NODE_TLS_REJECT_UNAUTHORIZED: 0
     steps:
       - name: Checkout and Lint
         uses: actions/checkout@v1
@@ -19,9 +21,6 @@ jobs:
           wait-on: 'https://localhost:8080'
           browser: chrome
           headless: true
-        env:
-          # This allows self-signed ssl certs to work so UATs run against https
-          NODE_TLS_REJECT_UNAUTHORIZED: 0
       - name: Archive test screenshots
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ jobs:
     env:
       ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
       ALGOLIA_KEY: ${{ secrets.ALGOLIA_KEY }}
+      API_BASE_URL: ${{ secrets.API_BASE_URL }}
       # This allows self-signed ssl certs to work so UATs run against https
       NODE_TLS_REJECT_UNAUTHORIZED: 0
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,4 @@ test/cypress/videos/**/*
 
 # Hidden files
 .env*
-!.env.example
 cypress.env.json
-!cypress.env.json.example

--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,5 @@ test/cypress/videos/**/*
 
 # Hidden files
 .env*
+!.env.example
 cypress.env.json

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ You need to have a version of Yarn that is >= 1.21.1 installed on the host machi
 2. Clone and `cd` into your new fork.
 3. Create a new branch from `master` with `git checkout -b someNewFeatureOrBugfixBranch`
 4. Install packages by running `yarn` command.
+5. Copy `.env.example` as `.env`.
+6. Go into your forked repo > Settings > Secrets and add a new *Secret*:  `API_BASE_URL` and make the value `https://dev-api.pbbg.com`.
 
 ### Commands
 * `yarn start` build app for production and serve on `http://localhost:8080` *purpose is for startup on production server*
@@ -47,15 +49,13 @@ default when developing locally (and also when Github Actions runs on your forke
 stubbed when your PR runs the Github Actions workflow in the source repo.
 
 For some development, you may need to have the actual integration working and functional. For this, you'll need to
-setup some environment variables at the root of your project:
-* Create an `.env` file in the root of your project and paste:
+create some new environment variables:
+* Add these to your `.env` file:
 ```
-# No quotes needed around string values here
 ALGOLIA_APP_ID=
 ALGOLIA_KEY=
-
 ```
-* In the same place, create a `cypress.env.json` file and paste:
+* In the root of your project create a `cypress.env.json` file and paste this:
 ```
 {
   "ALGOLIA_APP_ID": "",
@@ -76,6 +76,8 @@ the same values.
 ### Test Environment
 Development Front-End: [https://dev.pbbg.com/](https://dev.pbbg.com/)
 Development API: [https://dev-api.pbbg.com/](https://dev-api.pbbg.com/)
+API Swagger Docs [https://app.swaggerhub.com/apis-docs/pbbg/api.pbbg.com/0.1.3#/](https://app.swaggerhub.com/apis-docs/pbbg/api.pbbg.com/0.1.3#/)
+> Note as updates are made to the api.pbbg.com project the hash will increment from 0.1.3 > 0.1.4 > etc. So, always ensure you are viewing the latest docs.
 
 ## Licenses
 Content is released under [GNU GPL v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html).

--- a/README.md
+++ b/README.md
@@ -12,21 +12,6 @@ You need to have a version of Yarn that is >= 1.21.1 installed on the host machi
 3. Create a new branch from `master` with `git checkout -b someNewFeatureOrBugfixBranch`
 4. Install packages by running `yarn` command.
 
-### Set environment variables
-* Copy the `.env.example` and rename to `.env`. This lets you hit the real dev Algolia instance when running locally.
-
-* Copy the `cypress.env.json.example` and rename to `cypress.env.json`. This allows the UAT tests to correctly stub
-Algolia with mock data.
-
-* Copy the values for the `ALGOLIA_APP_ID` and `ALGOLIA_KEY` from the `/.github/workflows/main.yml` file and paste into
-both of your new files.
-
-> Curious as to why these values are checked into source control? Turns out Github Actions currently doesn't support sharing
-> secrets to forked repositories (i.e. for contributors making Pull Requests). Without this, your Github Actions in your
-> forked repository would always fail. Fortunately, these values are to a development instance of Algolia that is an
-> acceptable place to be publicly viewable. The production Algolia credentials can still be protected via the release
-> process in the source repository.
-
 ### Commands
 * `yarn start` build app for production and serve on `http://localhost:8080` *purpose is for startup on production server*
 > IMPORTANT - you may get a browser prevention due to scrambled info when running serve on localhost.
@@ -48,9 +33,49 @@ both of your new files.
 > Longer Contributing document on how to offer feedback, our standards, responsibilities, code of conduct, and
 >enforcement can be found in [contributing guidelines](/CONTRIBUTING.md)
 
+### Interacting with the database
+Currently, local development is not running it's own local database/api. The http requests are actually hitting the real
+dev API (https://dev-api.pbbg.com). This is partially because we want to treat the API as a truly third-party service.
+
+Keep this in mind as you write UATs - for example, if the API prevents duplicate fields and you rerun a test that
+creates something with those fields then you are likely to get 422 responses from the collisions. (See the `uniqueUser`
+and the `uniqueGameName` utility methods in the UAT tests for examples of how to work around this limitation).
+
+### Optional - connecting to the Algolia instance for search
+The integration with Algolia is rate limited by use and per level of payment plan, and therefore it is stubbed out by
+default when developing locally (and also when Github Actions runs on your forked repo branch). However, it is *NOT*
+stubbed when your PR runs the Github Actions workflow in the source repo.
+
+For some development, you may need to have the actual integration working and functional. For this, you'll need to
+setup some environment variables at the root of your project:
+* Create an `.env` file in the root of your project and paste:
+```
+# No quotes needed around string values here
+ALGOLIA_APP_ID=
+ALGOLIA_KEY=
+
+```
+* In the same place, create a `cypress.env.json` file and paste:
+```
+{
+  "ALGOLIA_APP_ID": "",
+  "ALGOLIA_KEY": ""
+}
+
+```
+* Ask a project contributor or @FoohonPie in Discord for the values to plug into these files.
+* Lastly, for your forked repo's Github Action (which runs UATs like they will run when you create your PR) you will
+need to go into your Forked Repo's settings > Secrets and add one for ALGOLIA_APP_ID and another for ALGOLIA_KEY using
+the same values.
+
+> Github Actions currently doesn't support sharing secrets to forked repositories (i.e. for contributors making Pull
+> Requests). Without the app_id and keys for Algolia, your Github Actions in your will run UATs against the Algolia
+> stub, the same as when you run them locally. However, they will use the "real thing" when your PR goes through the
+> Github Actions workflow in the source repo.
+
 ### Test Environment
- After developing locally and going through the normal Pull Request process to get your changes added, you should
- be able to see the updated code hosted on the test environment at [https://dev.pbbg.com/](https://dev.pbbg.com/).
+Development Front-End: [https://dev.pbbg.com/](https://dev.pbbg.com/)
+Development API: [https://dev-api.pbbg.com/](https://dev-api.pbbg.com/)
 
 ## Licenses
 Content is released under [GNU GPL v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html).

--- a/cypress.env.json.example
+++ b/cypress.env.json.example
@@ -1,4 +1,0 @@
-{
-  "ALGOLIA_APP_ID": "copyFromDotEnvFile",
-  "ALGOLIA_KEY": "copyFromDotEnvFile"
-}

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -51,6 +51,7 @@ module.exports = function (/* ctx */) {
       env: {
         ALGOLIA_APP_ID: process.env.ALGOLIA_APP_ID,
         ALGOLIA_KEY: process.env.ALGOLIA_KEY,
+        API_BASE_URL: process.env.API_BASE_URL,
       },
 
       // Add dependencies for transpiling with Babel (Array of string/regex)

--- a/src/boot/axios.js
+++ b/src/boot/axios.js
@@ -2,15 +2,9 @@ import axios from 'axios'
 import auth from '../services/auth'
 import { USER_PROFILE_UPDATED_ACTION } from '../store'
 
-const setBaseUrl = () => {
-  const isLocalHost = window.location.origin.includes('localhost')
-  const isDevEnvironment = window.location.origin.includes('dev-api.pbbg.com')
-  const apiBaseUrl = (isLocalHost || isDevEnvironment) ? 'https://dev-api.pbbg.com' : 'https://api.pbbg.com'
-  axios.defaults.baseURL = apiBaseUrl
-}
-
 export default async ({ store, Vue }) => {
-  setBaseUrl()
+  console.log('API Base URL environment variable is: ' + process.env.API_BASE_URL)
+  axios.defaults.baseURL = process.env.API_BASE_URL
   Vue.prototype.$axios = axios
 
   if (auth.loggedIn()) {

--- a/src/components/AlgoliaPlaceholder.vue
+++ b/src/components/AlgoliaPlaceholder.vue
@@ -1,0 +1,38 @@
+<template>
+  <div>
+    <div class="q-mb-lg">
+      <q-skeleton type="QInput">
+        <div class="text-center vertical-middle full-height">
+          Algolia search omitted; see README for more info
+        </div>
+      </q-skeleton>
+    </div>
+    <q-card
+      class="q-mb-lg"
+      flat
+      bordered
+      v-for="item of [0,1,2,3,4,5,6]"
+      :key="item"
+    >
+      <q-card-section class="row flex">
+        <q-skeleton
+          type="QAvatar"
+          class="rating-badge"
+        />
+        <q-skeleton
+          height="10rem"
+          width="10rem"
+        />
+        <q-card-section class="col">
+          <q-skeleton type="text" />
+          <q-skeleton type="text" />
+        </q-card-section>
+      </q-card-section>
+      <q-separator />
+      <q-card-section>
+        <q-skeleton type="text" />
+        <q-skeleton type="text" />
+      </q-card-section>
+    </q-card>
+  </div>
+</template>

--- a/src/components/SearchResult.vue
+++ b/src/components/SearchResult.vue
@@ -55,11 +55,4 @@ export default {
   .ad-square-button
     height: 10rem
     width: 10rem
-
-  .rating-badge
-    position: absolute
-    top: -1rem
-    left: -1rem
-    color: #ffffff
-    z-index: 4
 </style>

--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -24,3 +24,10 @@ body, html
 
 .user-forms-modal
   width: 40rem
+
+.rating-badge
+  position: absolute
+  top: -1rem
+  left: -1rem
+  color: #ffffff
+  z-index: 4

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -2,8 +2,12 @@
 export default {
   name: 'Index',
   components: {
+    AlgoliaPlaceholder: () => import('../components/AlgoliaPlaceholder.vue'),
     InstantSearch: () => import('../components/InstantSearch.vue'),
   },
+  data: () => ({
+    hasAlgoliaKeys: process.env.ALGOLIA_KEY && process.env.ALGOLIA_APP_ID,
+  }),
 }
 </script>
 
@@ -13,7 +17,8 @@ export default {
       <h1 class="smaller-h1 q-py-md q-my-none">
         The PBBG Directory
       </h1>
-      <instant-search />
+      <instant-search v-if="hasAlgoliaKeys" />
+      <algolia-placeholder v-else />
     </div>
   </q-page>
 </template>

--- a/test/cypress/integration/home.spec.js
+++ b/test/cypress/integration/home.spec.js
@@ -8,8 +8,4 @@ describe('Home', function () {
     cy.title().should('include', 'pbbg.com')
     cy.verifyHomepage()
   })
-
-  it('should see some test search results', () => {
-    cy.contains('Test Algolia Search Results').should('be.visible')
-  })
 })


### PR DESCRIPTION
This PR is addressing and fixes #19 .  To summarize:
* .env.example and cypress.env.json.example are now removed as the default developer setup doesn't require any .env at all.
* readme is updated with instructions for how a developer can optionally create the .env/cypress.env.json and add values in order to see the real Algolia.
* An Algolia "placeholder" skeleton graphic is shown in the user interface when the environment variables are not present (which is default now).
* Github Actions both in the user's forked repo and the source repo will run correctly.  The forked repo can either run without Github secrets, in which case the Algolia is stubbed out during the test run, or if the secrets are there it will use the real thing.