### PR TITLE
Cypress dashboard for recorded test runs and multiple runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 name: main
-on: [push]
+on:
+  push:
+  pull_request:
+    branches:
+      - master
 jobs:
   cypress-run:
     runs-on: ubuntu-16.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,18 +3,32 @@ on: [push]
 jobs:
   cypress-run:
     runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        node: [ 10, 12 ]
+    name: Build, Lint, and UATs on Node v${{ matrix.node }}
     env:
       ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
       ALGOLIA_KEY: ${{ secrets.ALGOLIA_KEY }}
       API_BASE_URL: ${{ secrets.API_BASE_URL }}
       # This allows self-signed ssl certs to work so UATs run against https
       NODE_TLS_REJECT_UNAUTHORIZED: 0
+      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Checkout and Lint
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - run: node -v
+
+      - name: Checkout
         uses: actions/checkout@v1
-      - name: Run ESLint
+
+      - name: Lint
         run: yarn && yarn lint
-      - name: Build app and Run UATs
+
+      - name: UATs
         uses: cypress-io/github-action@v2
         with:
           config-file: cypress.json
@@ -22,9 +36,5 @@ jobs:
           wait-on: 'https://localhost:8080'
           browser: chrome
           headless: true
-      - name: Archive test screenshots
-        uses: actions/upload-artifact@v1
-        with:
-          name: screenshots
-          path: test/cypress/screenshots
-        if: ${{ failure() }}
+          record: true
+          tag: node-${{ matrix.node }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,4 +53,4 @@ jobs:
           headless: true
           record: true
           tag: node-${{ matrix.node }}
-        if: github.repository == 'pbbg/pbbg.com' && github.event_name == 'push'
+        if: github.repository == 'pbbg/pbbg.com' && github.event_name == 'pull_request'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,17 @@ jobs:
       - name: Lint
         run: yarn && yarn lint
 
-      - name: UATs
+      - name: Contributor UATs
+        uses: cypress-io/github-action@v2
+        with:
+          config-file: cypress.json
+          start: yarn start
+          wait-on: 'https://localhost:8080'
+          browser: chrome
+          headless: true
+        if: github.repository != 'pbbg/pbbg.com' && github.event_name == 'push'
+
+      - name: Recorded UATs
         uses: cypress-io/github-action@v2
         with:
           config-file: cypress.json
@@ -39,3 +49,4 @@ jobs:
           headless: true
           record: true
           tag: node-${{ matrix.node }}
+        if: github.repository == 'pbbg/pbbg.com' && github.event_name == 'push'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
       # This allows self-signed ssl certs to work so UATs run against https
       NODE_TLS_REJECT_UNAUTHORIZED: 0
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+      CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Setup Node

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ You need to have a version of Yarn that is >= 1.21.1 installed on the host machi
 * `yarn lint:fix` lint the files for warnings and errors and try to automatically fix
 * `yarn test:e2e` open the UAT tool, Cypress, to select test files to run in the browser **Requires app to be running**
 * `yarn test:e2e:ci` run the UAT tests in headless browser mode (automatically run when you make a Pull Request) **Requires app to be running**
+> When running from your forked repository the Cypress Tests simply run, but when you create your Pull Request
+> they will be run and video/screenshots recorded and sent to the cypress.io dashboard
 
 ### Contributing and Pull Requests
 1. We *highly* encourage [short, concise git commit messages](https://chris.beams.io/posts/git-commit/).
@@ -82,6 +84,8 @@ API Swagger Docs [https://app.swaggerhub.com/apis-docs/pbbg/api.pbbg.com/0.1.3#/
 ## FAQ/issues
 * For Windows 10 development environment I cannot get cypress to run!
 > Answer: Try running `npx cypress install --force` which will reinstall cypress and then trying the normal UAT test command, `yarn test:e2e` while the app is already running.
+* UAT tests are failing when I create my PR!
+> Answer: Try checking the [Cypress.io Dashboard](https://dashboard.cypress.io/projects/befrjn/runs?branches=%5B%5D&committers=%5B%5D&flaky=%5B%5D&page=1&status=%5B%5D&tags=%5B%5D&timeRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D) and viewing the screenshots or videos of the failing test to troubleshoot what went wrong.
 
 ## Licenses
 Content is released under [GNU GPL v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html).

--- a/cypress.json
+++ b/cypress.json
@@ -11,5 +11,5 @@
   "testFiles": "**/*.spec.js",
   "viewportHeight": 720,
   "viewportWidth": 1280,
-  "projectId": "5a3zd1"
+  "projectId": "befrjn"
 }

--- a/cypress.json
+++ b/cypress.json
@@ -9,7 +9,7 @@
   "supportFile": "test/cypress/support/index.js",
   "videosFolder": "test/cypress/videos",
   "testFiles": "**/*.spec.js",
-  "video": false,
   "viewportHeight": 720,
-  "viewportWidth": 1280
+  "viewportWidth": 1280,
+  "projectId": "g3wnsk"
 }

--- a/cypress.json
+++ b/cypress.json
@@ -11,5 +11,5 @@
   "testFiles": "**/*.spec.js",
   "viewportHeight": 720,
   "viewportWidth": 1280,
-  "projectId": "g3wnsk"
+  "projectId": "5a3zd1"
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@quasar/cli": "^1.1.2",
     "@quasar/quasar-app-extension-dotenv": "^1.0.5",
     "babel-eslint": "^10.0.1",
-    "cypress": "^5.3.0",
+    "cypress": "5.4.0",
     "cypress-log-to-output": "^1.1.2",
     "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.0",

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -10,7 +10,7 @@ export default {
   async registerUser({ name, email, password }) {
     try {
       const response = await Vue.prototype.$axios.post('/register', { name, email, password })
-      this.setAxiosAuthHeader(response.data.token)
+      this.setAxiosAuthHeader(response.data.data.token)
       notify(messages.register(name))
     } catch(error) {
       let errorMessage = errorMessageFromApiResponse(error)
@@ -21,9 +21,9 @@ export default {
   async login({ email, password }) {
     try {
       const response = await Vue.prototype.$axios.post('/login', { email, password })
-      this.setAxiosAuthHeader(response.data.success.token)
+      this.setAxiosAuthHeader(response.data.data.token)
     } catch(error) {
-      if (error.response.data && error.response.data.error === 'Unauthorized') {
+      if (error.response.data && error.response.data.message === 'Unauthorized') {
         notify(messages.invalidLogin)
       } else {
         notify(messages.failLogin)
@@ -39,7 +39,7 @@ export default {
   async getUser() {
     try {
       const response = await Vue.prototype.$axios.get('/user')
-      return response.data
+      return response.data.data
     } catch(error) {
       notify(messages.failGetUser)
       return null

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -87,7 +87,9 @@ Cypress.Commands.add('loginUser', ({ email, password }) => {
 })
 
 Cypress.Commands.add('logout', (name = null) => {
-  cy.getAriaLabel(name).first().click() //there are two aria labels because quasar applies to any button inside a btn-dropdown
+  cy.get('header').within(() => {
+    cy.contains(name).click()
+  })
   cy.contains('Logout').click()
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1648,10 +1648,20 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4:
   version "6.12.5"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
   integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.12.3:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -1766,12 +1776,19 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+ansi-styles@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
   integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
   dependencies:
     "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
+
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
     color-convert "^2.0.1"
 
 ansi-wrap@0.1.0:
@@ -3517,10 +3534,10 @@ cypress-log-to-output@^1.1.2:
     chalk "^2.4.2"
     chrome-remote-interface "^0.27.1"
 
-cypress@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-5.3.0.tgz#91122219ae66ab910058970dbf36619ab0fbde6c"
-  integrity sha512-XgebyqL7Th6/8YenE1ddb7+d4EiCG2Jvg/5c8+HPfFFY/gXnOVhoCVUU3KW8qg3JL7g0B+iJbHd5hxuCqbd1RQ==
+cypress@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-5.4.0.tgz#8833a76e91129add601f823d43c53eb512d162c5"
+  integrity sha512-BJR+u3DRSYMqaBS1a3l1rbh5AkMRHugbxcYYzkl+xYlO6dzcJVE8uAhghzVI/hxijCyBg1iuSe4TRp/g1PUg8Q==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"
@@ -7238,10 +7255,15 @@ mkdirp@^1.0.3, mkdirp@^1.0.4, mkdirp@~1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@^2.22.1, moment@^2.27.0:
+moment@^2.22.1:
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.0.tgz#fcbef955844d91deb55438613ddcec56e86a3425"
   integrity sha512-z6IJ5HXYiuxvFTI6eiQ9dm77uE0gyy1yXNApVHqTcnIKfY9tIwEjlzsZ6u1LQXvVgKeTnv9Xm7NDvJ7lso3MtA==
+
+moment@^2.27.0:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -10396,10 +10418,15 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.10.0, tslib@^1.9.0:
+tslib@^1.10.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^1.9.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
This PR adds support for using the Cypress.io dashboard to more easily view/share viewing the UAT runs.  This'll help for troubleshooting and diagnosing failures as they happen in CI.

In main.yml, I am:
* Declaring to run on both Node 10 and Node 12 (they run in parallel)
* The UAT step is now two steps conditionally run depending on if the GH Action is running in source repo or forked repo.
* Only record UATs and send to Cypress dashboard when running from pbbg/pbbg.com

Additionally, some of the data shape of /user, /login, /register changed in the API and need to be adjusted here.  A issue will be opened to fix that, but it should be working for the time being.