### PR TITLE
News feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ the same values.
 ### Test Environment
 Development Front-End: [https://dev.pbbg.com/](https://dev.pbbg.com/)
 Development API: [https://dev-api.pbbg.com/](https://dev-api.pbbg.com/)
-API Swagger Docs [https://app.swaggerhub.com/apis-docs/pbbg/api.pbbg.com/0.1.3#/](https://app.swaggerhub.com/apis-docs/pbbg/api.pbbg.com/0.1.3#/)
+API Swagger Docs [https://app.swaggerhub.com/apis-docs/pbbg/api.pbbg.com/0.1.6#/](https://app.swaggerhub.com/apis-docs/pbbg/api.pbbg.com/0.1.6#/)
 > Note as updates are made to the api.pbbg.com project the hash will increment from 0.1.3 > 0.1.4 > etc. So, always ensure you are viewing the latest docs.
 
 ## FAQ/issues

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -54,6 +54,10 @@ module.exports = function (/* ctx */) {
         API_BASE_URL: process.env.API_BASE_URL,
       },
 
+      sassLoaderOptions: {
+        prependData: '@import "./src/css/app.sass";',
+      },
+
       // Add dependencies for transpiling with Babel (Array of string/regex)
       // (from node_modules, which are by default not transpiled).
       // Applies only if "transpile" is set to true.

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,3 +1,12 @@
+<script>
+import { INITIAL_APP_LOAD_ACTION } from './store'
+export default {
+  created() {
+    this.$store.dispatch(INITIAL_APP_LOAD_ACTION)
+  },
+}
+</script>
+
 <template>
   <div id="q-app">
     <router-view />

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,10 @@ export default {
 </script>
 
 <template>
-  <div id="q-app">
+  <div
+    id="q-app"
+    class="pbbg"
+  >
     <router-view />
   </div>
 </template>

--- a/src/components/NewsFeed.vue
+++ b/src/components/NewsFeed.vue
@@ -1,0 +1,72 @@
+<script>
+import { mapState } from 'vuex'
+
+export default {
+  computed: {
+    ...mapState(['feed']),
+  },
+}
+</script>
+
+<template>
+  <q-list
+    bordered
+    separator
+    class="rounded-borders relative-position"
+  >
+    <q-item
+      v-for="(item, index) in feed"
+      :key="index"
+      class="q-pa-md"
+    >
+      <q-item-section avatar>
+        <q-avatar>
+          <img :src="item.image_url">
+        </q-avatar>
+      </q-item-section>
+
+      <q-item-section>
+        <q-item-label lines="1">
+          <a
+            :href="item.feed_source"
+            target="_blank"
+          >
+            {{ item.feed_name }}
+          </a>
+        </q-item-label>
+        <q-item-label class="q-pt-sm">
+          <a
+            :href="item.url"
+            target="_blank"
+          >
+            {{ item.title }}
+          </a>
+        </q-item-label>
+      </q-item-section>
+
+      <q-item-section
+        top
+        class="corner-content absolute-right q-pt-md q-mr-sm text-body2 text-grey"
+      >
+        {{ item.timestamp }}
+      </q-item-section>
+    </q-item>
+    <q-inner-loading
+      :showing="!feed.length > 0"
+    >
+      <q-spinner-radio
+        size="2rem"
+        color="primary"
+        aria-label="News Feed Loading Icon"
+      />
+    </q-inner-loading>
+  </q-list>
+</template>
+
+<style lang="sass" scoped>
+.feed-minimum-size
+  min-height: 30rem
+  width: 25rem
+.corner-content
+  line-height: 1rem
+</style>

--- a/src/components/NewsFeed.vue
+++ b/src/components/NewsFeed.vue
@@ -12,7 +12,7 @@ export default {
   <q-list
     bordered
     separator
-    class="rounded-borders relative-position"
+    class="rounded-borders relative-position feed-minimum-height"
   >
     <q-item
       v-for="(item, index) in feed"
@@ -64,9 +64,8 @@ export default {
 </template>
 
 <style lang="sass" scoped>
-.feed-minimum-size
+.feed-minimum-height
   min-height: 30rem
-  width: 25rem
 .corner-content
   line-height: 1rem
 </style>

--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -4,30 +4,68 @@
 body, html
   color: $secondary
 
-.smaller-h1
-  font-size: 2.25rem
-  line-height: 2.25rem
+.pbbg
+  .smaller-h1
+    font-size: 2.25rem
+    line-height: 2.25rem
 
-.top-left-round
-  border-top-left-radius: .25rem
-.top-right-round
-  border-top-right-radius: .25rem
+  .top-left-round
+    border-top-left-radius: .25rem
+  .top-right-round
+    border-top-right-radius: .25rem
 
-.border-all
-  border: 1px solid $separator-color
-  border-radius: .25rem
+  .border-all
+    border: 1px solid $separator-color
+    border-radius: .25rem
 
-.no-top-left-border
-  border-top-left-radius: 0
-.no-top-right-border
-  border-top-right-radius: 0
+  .no-top-left-border
+    border-top-left-radius: 0
+  .no-top-right-border
+    border-top-right-radius: 0
 
-.user-forms-modal
-  width: 40rem
+  .user-forms-modal
+    width: 40rem
 
-.rating-badge
-  position: absolute
-  top: -1rem
-  left: -1rem
-  color: #ffffff
-  z-index: 4
+  .rating-badge
+    position: absolute
+    top: -1rem
+    left: -1rem
+    color: #ffffff
+    z-index: 4
+
+  .full-width-column
+    width: 100%
+
+  .wide-column
+    width: 100%
+    max-width: 50rem
+
+  .slim-column
+    width: 25rem
+    max-width: 25rem
+    min-width: 25rem
+    min-height: 30rem
+
+  .meld-bottom
+    border-bottom: 0 solid transparent
+    border-bottom-left-radius: 0
+    border-bottom-right-radius: 0
+    padding-bottom: 0
+  .meld-top
+    border-top: 0 solid transparent
+    border-top-left-radius: 0
+    border-top-right-radius: 0
+    padding-top: 0
+
+  .single-input-style
+    display: flex
+    align-items: center
+    justify-content: space-between
+    .field-row
+      flex: 1
+    .actions
+      max-width: 8rem
+      flex: 1
+      align-self: baseline
+      height: 3.5rem
+      padding-left: .5rem

--- a/src/pages/Create.vue
+++ b/src/pages/Create.vue
@@ -61,31 +61,3 @@ export default {
     </div>
   </q-page>
 </template>
-
-<style lang="sass" scoped>
-  @import '../css/app.sass'
-
-  .meld-bottom
-    border-bottom: 0 solid transparent
-    border-bottom-left-radius: 0
-    border-bottom-right-radius: 0
-    padding-bottom: 0
-  .meld-top
-    border-top: 0 solid transparent
-    border-top-left-radius: 0
-    border-top-right-radius: 0
-    padding-top: 0
-
-  .single-input-style /deep/
-      display: flex
-      align-items: center
-      justify-content: space-between
-      .field-row
-        flex: 1
-      .actions
-        max-width: 8rem
-        flex: 1
-        align-self: baseline
-        height: 3.5rem
-        padding-left: .5rem
-</style>

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -4,6 +4,7 @@ export default {
   components: {
     AlgoliaPlaceholder: () => import('../components/AlgoliaPlaceholder.vue'),
     InstantSearch: () => import('../components/InstantSearch.vue'),
+    NewsFeed: () => import('../components/NewsFeed.vue'),
   },
   data: () => ({
     hasAlgoliaKeys: process.env.ALGOLIA_KEY && process.env.ALGOLIA_APP_ID,
@@ -12,13 +13,28 @@ export default {
 </script>
 
 <template>
-  <q-page class="row justify-center items-start">
-    <div class="column col-12 col-sm-10 col-md-8 q-pa-md">
+  <q-page
+    class="row justify-center items-baseline"
+    :class="{'column': $q.screen.lt.md}"
+  >
+    <div
+      class="col column q-pa-md"
+      :class="{'full-width-column': $q.screen.lt.md, 'wide-column': $q.screen.gt.sm}"
+    >
       <h1 class="smaller-h1 q-py-md q-my-none">
         The PBBG Directory
       </h1>
       <instant-search v-if="hasAlgoliaKeys" />
       <algolia-placeholder v-else />
+    </div>
+    <div
+      class="col column q-pa-md"
+      :class="{'full-width-column': $q.screen.lt.md, 'slim-column': $q.screen.gt.sm}"
+    >
+      <h1 class="smaller-h1 q-py-md q-my-none">
+        News Feed
+      </h1>
+      <news-feed />
     </div>
   </q-page>
 </template>

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -1,4 +1,5 @@
-import { Loading } from 'quasar'
+import { Loading, date } from 'quasar'
+const { formatDate } = date
 
 export const mockGameInfoHttpRequest = async url => {
   // mocking the api request until the endpoint is implemented
@@ -51,4 +52,9 @@ export const validEmailString = value => {
 
 export const isMatchingPasswords = (pass1, pass2) => {
   return pass1.trim() === pass2.trim()
+}
+
+export const dateFromUnixTimestamp = unixTimestamp => {
+  const timestamp = unixTimestamp * 1000
+  return formatDate(parseInt(timestamp, 10), 'MMMM D YYYY')
 }

--- a/src/store.js
+++ b/src/store.js
@@ -1,7 +1,12 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 import router from './router'
-import { mockGameInfoHttpRequest, errorMessageFromApiResponse, asyncRequestWithLoader } from './services/utils'
+import {
+  mockGameInfoHttpRequest,
+  errorMessageFromApiResponse,
+  asyncRequestWithLoader,
+  dateFromUnixTimestamp,
+} from './services/utils'
 import { notify, messages } from './services/messages'
 import auth from './services/auth'
 Vue.use(Vuex)
@@ -15,16 +20,20 @@ export const USER_REGISTRATION_SUBMIT_ACTION = 'USER_REGISTRATION_SUBMIT_ACTION'
 export const USER_LOGIN_SUBMIT_ACTION = 'USER_LOGIN_SUBMIT_ACTION'
 export const USER_LOGOUT_PRESS_ACTION = 'USER_LOGOUT_PRESS_ACTION'
 export const USER_PROFILE_UPDATED_ACTION = 'USER_PROFILE_UPDATED_ACTION'
+export const INITIAL_APP_LOAD_ACTION = 'INITIAL_APP_LOAD_ACTION'
+export const NEWS_FEED_LOAD_ACTION = 'NEWS_FEED_LOAD_ACTION'
 
 const SET_NAV_DRAWER_MUTATION = 'SET_NAV_DRAWER_MUTATION'
 const RESET_INFO_MUTATION = 'RESET_INFO_MUTATION'
 const SET_INFO_MUTATION = 'SET_INFO_MUTATION'
 const SET_USER_MUTATION = 'SET_USER_MUTATION'
+const SET_FEED_MUTATION = 'SET_FEED_MUTATION'
 
 const initialState = () => ({
   navDrawerOpen: false,
   gameInfo: null,
   user: null,
+  feed: [],
 })
 
 const setValue = key => (state, val) => {
@@ -102,12 +111,24 @@ export default new Vuex.Store({
         },
       })
     },
+    async [INITIAL_APP_LOAD_ACTION]({ dispatch }) {
+      dispatch(NEWS_FEED_LOAD_ACTION)
+    },
+    async [NEWS_FEED_LOAD_ACTION]({ commit }) {
+      const feedsResponse = await Vue.prototype.$axios.get('/feeds')
+      const feedItems = feedsResponse.data.data
+      for (const item of feedItems) {
+        item.timestamp = dateFromUnixTimestamp(item.timestamp)
+      }
+      commit(SET_FEED_MUTATION, feedItems)
+    },
   },
   mutations: {
     [SET_NAV_DRAWER_MUTATION]: setValue('navDrawerOpen'),
     [RESET_INFO_MUTATION]: setValue('gameInfo'),
     [SET_INFO_MUTATION]: setValue('gameInfo'),
     [SET_USER_MUTATION]: setValue('user'),
+    [SET_FEED_MUTATION]: setValue('feed'),
   },
   getters: {},
 })

--- a/test/cypress/integration/createGame.spec.js
+++ b/test/cypress/integration/createGame.spec.js
@@ -1,4 +1,4 @@
-import { uniqueGameUrl } from '../util'
+import { uniqueGameUrl, uniqueGameName } from '../util'
 
 describe('Create Game', function () {
   beforeEach(() => {
@@ -16,7 +16,7 @@ describe('Create Game', function () {
     cy.goCreateGame()
     cy.createNewGameRequest({
       url,
-      name: 'GameOne',
+      name: uniqueGameName(),
       shortDescription: 'Game One Description',
     })
     cy.verifyHomepage()
@@ -40,7 +40,7 @@ describe('Create Game', function () {
     cy.typeIntoFormField('URL *', uniqueGameUrl())
     cy.contains('GET INFO').click()
 
-    cy.typeIntoFormField('Name *', 'TestGame')
+    cy.typeIntoFormField('Name *', uniqueGameName())
     cy.typeIntoFormField('Short Description *', 'a big long description here and some more text.')
     cy.contains('Save').click()
     cy.verifyHomepage()
@@ -56,7 +56,7 @@ describe('Create Game', function () {
 
     cy.expectHTML5ValidationMessage('text', 'Please fill out this field.')
 
-    cy.typeIntoFormField('Name *', 'TestGame')
+    cy.typeIntoFormField('Name *', uniqueGameName())
     cy.contains('Save').click()
     cy.verifyHomepage()
     cy.contains('Success!').should('be.visible')
@@ -66,7 +66,7 @@ describe('Create Game', function () {
     cy.goCreateGame()
     cy.typeIntoFormField('URL *', uniqueGameUrl())
     cy.contains('GET INFO').click()
-    cy.typeIntoFormField('Name *', 'TestGame')
+    cy.typeIntoFormField('Name *', uniqueGameName())
     cy.contains('Save').click()
 
     cy.expectHTML5ValidationMessage('textarea', 'Please fill out this field.')

--- a/test/cypress/integration/home.spec.js
+++ b/test/cypress/integration/home.spec.js
@@ -8,4 +8,9 @@ describe('Home', function () {
     cy.title().should('include', 'pbbg.com')
     cy.verifyHomepage()
   })
+
+  it('should retrieve the news feed when homepage loads', () => {
+    cy.contains('News Feed').should('be.visible')
+    cy.getAriaLabel('News Feed Loading Icon').should('not.be.visible')
+  })
 })


### PR DESCRIPTION
This adds the News Feed to the homepage for auth and un-auth'd users.
* There is a new `INITIAL_APP_LOAD_ACTION` which is used now (and can be used in future) for any app startup data fetching.  After retrieving the news feed items, we keep that array in the Vuex store and do not fetch again until the next app load (i.e. browser refresh).
* `App.sass` file styles are now prepended during the compilation via `quasar.conf.js`.  This means any style in `App.sass` is accessible to all current/future components without needing to `@import` that file.
* Using a more streamlined and consistent approach for uniform dual/single column responsive grid with `$q.screen.xx.xx`.  You can see that [here](https://github.com/pbbg/pbbg.com/compare/master...bpkennedy:newsFeed?diff=unified&expand=1#diff-75f76a7ed2a0f45f79ae96d58b3530c71c8b88cc3612a84ffd784ba8df2e3cbaR22). Using this approach would let us create consistent layout "templates" pretty easily.
* Was able to use the built in Date util from quasar for friendly display dates and avoid adding another package 💪 