### PR TITLE
Image wrapper

### DIFF
--- a/src/components/SafeImg.vue
+++ b/src/components/SafeImg.vue
@@ -7,26 +7,32 @@ export default {
     },
     timeout: {
       type: Number,
-      default: 4000,
+      default: 6000,
+    },
+    title: {
+      type: String,
+      default: '',
     },
   },
   data: () => ({
-    imageElement: null,
-    isValidUrl: false,
-    validationTimer: null,
+    isValidUrl: true,
+    timer: null,
   }),
   methods: {
-    setAsValidUrl() {
-      this.isValidUrl = true
-      this.imageElement = new window.Image()
-      this.imageElement.src = this.src
-    },
-    invalidateAfterTimeoutIfBadUrl() {
-      this.validationTimer = setTimeout(() => {
-        if (!this.imageElement.complete || !this.imageElement.naturalWidth) {
+    testImageUrl() {
+      const imageElement = new window.Image()
+      imageElement.src = this.src
+      this.timer = setTimeout(() => {
+        if (!imageElement.complete || !imageElement.naturalWidth) {
           this.isValidUrl = false
         }
       }, this.timeout)
+    },
+    initialize() {
+      window.clearTimeout(this.timer)
+      this.isValidUrl = true
+      this.timer = null
+      this.testImageUrl()
     },
   },
   watch: {
@@ -34,14 +40,13 @@ export default {
       immediate: true,
       handler(newValue) {
         if (newValue) {
-          this.setAsValidUrl()
-          this.invalidateAfterTimeoutIfBadUrl()
+          this.initialize()
         }
       },
     },
   },
   beforeDestroy: function() {
-    window.clearTimeout(this.validationTimer)
+    window.clearTimeout(this.timer)
   },
 }
 </script>
@@ -50,7 +55,9 @@ export default {
   <div>
     <q-img
       :src="src"
+      :alt="title"
       @error="isValidUrl = false"
+      native-context-menu
       class="full-width full-height"
     >
       <template #loading>
@@ -61,9 +68,15 @@ export default {
       </template>
       <div
         v-if="!isValidUrl"
-        class="absolute-full flex flex-center bg-negative text-white"
+        class="absolute-full flex flex-center bg-grey-4 text-grey-8"
       >
-        Cannot load image
+        <div class="text-center">
+          Cannot load <br><a
+            :href="src"
+            target="_blank"
+            rel="noopener noreferrer"
+          >image url</a>
+        </div>
       </div>
     </q-img>
   </div>

--- a/src/components/SafeImg.vue
+++ b/src/components/SafeImg.vue
@@ -1,0 +1,70 @@
+<script>
+export default {
+  props: {
+    src: {
+      type: String,
+      default: '',
+    },
+    timeout: {
+      type: Number,
+      default: 4000,
+    },
+  },
+  data: () => ({
+    imageElement: null,
+    isValidUrl: false,
+    validationTimer: null,
+  }),
+  methods: {
+    setAsValidUrl() {
+      this.isValidUrl = true
+      this.imageElement = new window.Image()
+      this.imageElement.src = this.src
+    },
+    invalidateAfterTimeoutIfBadUrl() {
+      this.validationTimer = setTimeout(() => {
+        if (!this.imageElement.complete || !this.imageElement.naturalWidth) {
+          this.isValidUrl = false
+        }
+      }, this.timeout)
+    },
+  },
+  watch: {
+    src: {
+      immediate: true,
+      handler(newValue) {
+        if (newValue) {
+          this.setAsValidUrl()
+          this.invalidateAfterTimeoutIfBadUrl()
+        }
+      },
+    },
+  },
+  beforeDestroy: function() {
+    window.clearTimeout(this.validationTimer)
+  },
+}
+</script>
+
+<template>
+  <div>
+    <q-img
+      :src="src"
+      @error="isValidUrl = false"
+      class="full-width full-height"
+    >
+      <template #loading>
+        <q-spinner
+          color="secondary"
+          size="1em"
+        />
+      </template>
+      <div
+        v-if="!isValidUrl"
+        class="absolute-full flex flex-center bg-negative text-white"
+      >
+        Cannot load image
+      </div>
+    </q-img>
+  </div>
+</template>

--- a/src/components/SearchResult.vue
+++ b/src/components/SearchResult.vue
@@ -30,6 +30,7 @@ export default {
       <safe-img
         class="col-2 rounded-borders ad-square-button"
         :src="result.ad_square_button"
+        :alt="result.name + ' Game Image'"
       />
       <q-card-section class="col">
         <div class="text-h5 q-mt-sm q-mb-xs">

--- a/src/components/SearchResult.vue
+++ b/src/components/SearchResult.vue
@@ -1,6 +1,9 @@
 <script>
 export default {
   name: 'SearchResult',
+  components: {
+    SafeImg: () => import('./SafeImg.vue'),
+  },
   props: {
     result: {
       type: Object,
@@ -24,7 +27,7 @@ export default {
       >
         {{ result.rating }}
       </q-avatar>
-      <q-img
+      <safe-img
         class="col-2 rounded-borders ad-square-button"
         :src="result.ad_square_button"
       />


### PR DESCRIPTION
Adds new component, used like `<safe-image src="https://someUserDefinedUrl.jpg" :timeout="6000" alt="Some Alt Text"/>`.  In addition to using all the default features of `<q-img />` from quasar framework, this component can do:
* Shows a spinner while loading src url
* If `onerror` is triggered (i.e. malformed url or 404 from source), an error message is presented in place of the image with a copy-able href of the malformed/404 link.
* Use an optional `timeout` number prop.  The parent component can define a maximum time to try loading in the event of a long-running network request.  In this manner, some images do not spin forever while the source server fails to send back a response. If timeout is reached, it will show an error just like if a normal `onerror` event happened.
* Use an optional `alt` string prop for the image alt attribute.

Also this fixes #40 .