### PR TITLE
Brotli and gzip compression for all built static files

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@quasar/quasar-app-extension-dotenv": "^1.0.5",
     "@quasar/quasar-app-extension-qmarkdown": "^1.2.1",
     "babel-eslint": "^10.0.1",
+    "compression-webpack-plugin": "4.0.0",
     "cypress": "6.0.0",
     "cypress-log-to-output": "^1.1.2",
     "eslint": "^7.14.0",

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -7,6 +7,9 @@
 // https://quasar.dev/quasar-cli/quasar-conf-js
 /* eslint-env node */
 
+const CompressionPlugin = require('compression-webpack-plugin')
+const zlib = require('zlib')
+
 module.exports = function (/* ctx */) {
   return {
     // https://quasar.dev/quasar-cli/supporting-ts
@@ -75,6 +78,29 @@ module.exports = function (/* ctx */) {
           loader: 'eslint-loader',
           exclude: /node_modules/,
         })
+
+        // fallback to gzip compression for clients that don't support brotli
+        cfg.plugins.push(new CompressionPlugin({
+          filename: '[path].gz',
+          algorithm: 'gzip',
+          test: /\.(js|css|html)$/,
+          // threshold: 10240,  // commented out so that all code splitting files are compressed
+          minRatio: 0.8,
+        }))
+
+        // brotli compression at highest quality
+        cfg.plugins.push(new CompressionPlugin({
+          filename: '[path].br',
+          algorithm: 'brotliCompress',
+          test: /\.(js|css|html|svg)$/,
+          compressionOptions: {
+            params: {
+              [zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+            },
+          },
+          // threshold: 10240,  // commented out so that all code splitting files are compressed
+          minRatio: 0.8,
+        }))
       },
     },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2575,7 +2575,7 @@ cacache@^12.0.2:
     unique-filename "^1.1.1"
     y18n "^4.0.0"
 
-cacache@^15.0.5:
+cacache@^15.0.3, cacache@^15.0.5:
   version "15.0.5"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.0.5.tgz#69162833da29170d6732334643c60e005f5f17d0"
   integrity sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==
@@ -3151,6 +3151,17 @@ compressible@~2.0.16:
   integrity sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==
   dependencies:
     mime-db ">= 1.43.0 < 2"
+
+compression-webpack-plugin@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-4.0.0.tgz#7599f592050002a49cd3ad3ee18ae7371e266bca"
+  integrity sha512-DRoFQNTkQ8gadlk117Y2wxANU+MDY56b1FIZj/yJXucBOTViTHXjthM7G9ocnitksk4kLzt1N2RLF0gDjxI+hg==
+  dependencies:
+    cacache "^15.0.3"
+    find-cache-dir "^3.3.1"
+    schema-utils "^2.6.6"
+    serialize-javascript "^3.0.0"
+    webpack-sources "^1.4.3"
 
 compression-webpack-plugin@5.0.1:
   version "5.0.1"
@@ -9279,7 +9290,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.6.5, schema-utils@^2.7.0, schema-utils@^2.7.1:
+schema-utils@^2.6.5, schema-utils@^2.6.6, schema-utils@^2.7.0, schema-utils@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.1.tgz#1ca4f32d1b24c590c203b8e7a50bf0ea4cd394d7"
   integrity sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==
@@ -9379,7 +9390,7 @@ serialize-error@^7.0.1:
   dependencies:
     type-fest "^0.13.1"
 
-serialize-javascript@^3.1.0:
+serialize-javascript@^3.0.0, serialize-javascript@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
   integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==


### PR DESCRIPTION
This uses the [compression-webpack-plugin](https://github.com/webpack-contrib/compression-webpack-plugin) to have webpack compress the /dist files that are built using two compression algorithms: brotli and gzip.

All js/css/html/svg files should now have additional copies with .br and .gz extensions.  The webserver can be configured to serve brotli assets to clients unless they don't support it and then it can fallback to serving the gzip versions.  