### PR TITLE
Portainer Reload after CI build

### DIFF
--- a/.github/workflows/pbbg-development.yml
+++ b/.github/workflows/pbbg-development.yml
@@ -1,5 +1,5 @@
 name: PBBG Development Build
-
+# Should run whenever a push to Master branch is made
 on:
   push:
     branches: [ master ]
@@ -39,3 +39,9 @@ jobs:
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
         run: |
           chmod 755 ./scripts/push-images.sh; ./scripts/push-images.sh --username=${{secrets.DOCKER_USER}} --password=${{secrets.DOCKER_PASSWORD}}
+      - name: Update Portainer Stack in Development
+          env:
+            PORTAINER_USER: ${{secrets.PORTAINER_USER}}
+            PORTAINER_PASSWORD: ${{secrets.PORTAINER_PASSWORD}}
+          run: |
+            chmod 755 ./scripts/update-portainer-stack.sh; ./scripts/update-portainer-stack.sh --portainer_username=${{secrets.PORTAINER_USER}} --portainer_password=${{secrets.PORTAINER_PASSWORD}}

--- a/.github/workflows/pbbg-production.yml
+++ b/.github/workflows/pbbg-production.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build development images
+      - name: Build production images
         env:
           APP_NAME: ${{secrets.APP_NAME}}
           APP_ENV: ${{secrets.APP_ENV}}
@@ -31,9 +31,9 @@ jobs:
           QUEUE_CONNECTION: ${{secrets.QUEUE_CONNECTION}}
           SESSION_DRIVER: ${{secrets.SESSION_DRIVER}}
           SESSION_LIFETIME: ${{secrets.SESSION_LIFETIME}}
-          MAIL_DRIVER: ${{MAIL_DRIVER}}
-          MAIL_HOST: ${{MAIL_HOST}}
-          MAIL_PORT: ${{MAIL_PORT}}
+          MAIL_DRIVER: ${{secrets.MAIL_DRIVER}}
+          MAIL_HOST: ${{secrets.MAIL_HOST}}
+          MAIL_PORT: ${{secrets.MAIL_PORT}}
         run: |
           chmod 755 ./scripts/build-images.sh; ./scripts/build-images.sh production
       - name: Push images to Docker Hub
@@ -41,4 +41,10 @@ jobs:
           DOCKER_USER: ${{secrets.DOCKER_USER}}
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
         run: |
-          chmod 755 ./scripts/push-images.sh; ./scripts/push-images.sh -username ${{secrets.DOCKER_USER}} -password ${{secrets.DOCKER_PASSWORD}} -production true
+          chmod 755 ./scripts/push-images.sh; ./scripts/push-images.sh --username=${{secrets.DOCKER_USER}} --password=${{secrets.DOCKER_PASSWORD}} --production=true
+      - name: Update Portainer Stack in Production
+          env:
+            PORTAINER_USER: ${{secrets.PORTAINER_USER}}
+            PORTAINER_PASSWORD: ${{secrets.PORTAINER_PASSWORD}}
+          run: |
+            chmod 755 ./scripts/update-portainer-stack.sh; ./scripts/update-portainer-stack.sh --portainer_username=${{secrets.PORTAINER_USER}} --portainer_password=${{secrets.PORTAINER_PASSWORD}} --production=true

--- a/frontend/src/components/HelloWorld.vue
+++ b/frontend/src/components/HelloWorld.vue
@@ -6,7 +6,7 @@
       check out the
       <a href="https://cli.vuejs.org" target="_blank" rel="noopener">vue-cli documentation</a>.
     </p>
-    <h3>Installed CLI Plugins</h3>
+    <h3>Installed CLI Pluginszzz</h3>
     <ul>
       <li><a href="https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-babel" target="_blank" rel="noopener">babel</a></li>
       <li><a href="https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-router" target="_blank" rel="noopener">router</a></li>

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+# IMPORTANT: this script is intended to be used during the Github Actions build steps
 # This script builds images
 # Development Usage: ./build-images.sh
 # Production  Usage: ./build-images.sh production
@@ -13,14 +14,14 @@ production=$1
 devTag=master
 prodTag=release
 
-echo "==== build-images.sh script ===="
-echo "Stopping running containers..."
+echo $(date -u) "==== build-images.sh script ===="
+echo $(date -u) "Stopping running containers..."
 docker-compose down
 
-echo "Deleting stopped containers..."
+echo $(date -u) "Deleting stopped containers..."
 docker-compose rm
 
-echo "Deleting existing development images..."
+echo $(date -u) "Deleting existing development images..."
 if [ "$(docker image ls -a | grep frontend | grep $devTag)" ]; then
   docker rmi pbbg/frontend:$devTag
 fi
@@ -33,9 +34,9 @@ fi
 if [ "$(docker image ls -a | grep proxy | grep $devTag)" ]; then
   docker rmi pbbg/proxy:$devTag
 fi
-echo "${YELLOW}Successfully deleted development images...${NC}"
+echo $(date -u) "${YELLOW}Successfully deleted development images...${NC}"
 
-echo "Deleting existing production images..."
+echo $(date -u) "Deleting existing production images..."
 if [ "$(docker image ls -a | grep frontend | grep $prodTag)" ]; then
   docker rmi pbbg/frontend:$prodTag
 fi
@@ -48,15 +49,15 @@ fi
 if [ "$(docker image ls -a | grep proxy | grep $prodTag)" ]; then
   docker rmi pbbg/proxy:$prodTag
 fi
-echo "${CYAN}Successfully deleted production images...${NC}"
+echo $(date -u) "${CYAN}Successfully deleted production images...${NC}"
 
-if [[ -n "$production" ]]; then
-  echo "Building production images..."
+if [ -n "$production" ]; then
+  echo $(date -u) "Building production images..."
   docker-compose -f docker-compose.build-for-prod.yml build --parallel
-  echo "${CYAN}Successfully built production  images${NC}"
+  echo $(date -u) "${CYAN}Successfully built production  images${NC}"
 else
-  echo "Building development images..."
+  echo $(date -u) "Building development images..."
   docker-compose build --parallel
-  echo "${YELLOW}Successfully built development images${NC}"
+  echo $(date -u) "${YELLOW}Successfully built development images${NC}"
 fi
 

--- a/scripts/install-portainer.sh
+++ b/scripts/install-portainer.sh
@@ -6,16 +6,16 @@ set -e
 GREEN='\033[1;32m'
 NC='\033[0m' # No Color
 
-echo "==== install-portainer.sh script ===="
+echo $(date -u) "==== install-portainer.sh script ===="
 
-echo "Using bcrypt runtime docker container to create an encrypted password..."
+echo $(date -u) "Using bcrypt runtime docker container to create an encrypted password..."
 # Initial password is bcrypt encrypted password 'admin' using one-time run of httpd:2.4-alpine container
 password=docker run --rm httpd:2.4-alpine htpasswd -nbB admin "admin" | cut -d ":" -f 2
 
-echo "Creating docker volume for Portainer data..."
+echo $(date -u) "Creating docker volume for Portainer data..."
 docker volume create portainer_data
 
-echo "Starting Portainer.io standalone container, listening on port 9000..."
+echo $(date -u) "Starting Portainer.io standalone container, listening on port 9000..."
 docker run -d -p 9000:9000 --name=portainer --restart=always -v /var/run/docker.sock:/var/run/docker.sock -v portainer_data:/data portainer/portainer-ce --admin-password=$password
-echo "${GREEN}Successfully started Portainer.${NC}"
-echo "${GREEN}Portainer UI is available on {static_ip_address}:9000${NC}"
+echo $(date -u) "${GREEN}Successfully started Portainer.${NC}"
+echo $(date -u) "${GREEN}Portainer UI is available on {static_ip_address}:9000${NC}"

--- a/scripts/local-start.sh
+++ b/scripts/local-start.sh
@@ -6,19 +6,19 @@ GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-echo "==== local-start.sh script ===="
+echo $(date -u) "==== local-start.sh script ===="
 
-echo "Bringing down running containers..."
+echo $(date -u) "Bringing down running containers..."
 docker-compose down
-echo "${GREEN}Successfully stopped containers.${NC}"
+echo $(date -u) "${GREEN}Successfully stopped containers.${NC}"
 
-echo "Building development images in parallel..."
+echo $(date -u) "Building development images in parallel..."
 docker-compose build --parallel
-echo "${GREEN}Successfully built development images.${NC}"
+echo $(date -u) "${GREEN}Successfully built development images.${NC}"
 
-echo "Starting containers..."
+echo $(date -u) "Starting containers..."
 docker-compose up -d
-echo "${GREEN}Successfully started containers.${NC}"
+echo $(date -u) "${GREEN}Successfully started containers.${NC}"
 
-echo "${YELLOW}Containers have executed their final CMD, RUN, or ENTRYPOINT commands and may not have finished installing their own dependencies.${NC}"
-echo "${GREEN}Proxy entry should be accessible on host machine at http://localhost${NC}"
+echo $(date -u) "${YELLOW}Containers have executed their final CMD, RUN, or ENTRYPOINT commands and may not have finished installing their own dependencies.${NC}"
+echo $(date -u) "${GREEN}Proxy entry should be accessible on host machine at http://localhost${NC}"

--- a/scripts/push-images.sh
+++ b/scripts/push-images.sh
@@ -1,15 +1,16 @@
 #!/bin/sh
 set -e
-# This script pushes EXISTING images to Docker Hub - this script is only meant for PBBG Maintainers to use!
-# Development Usage: ./push-images.sh --username myUserName --password myPassword
-# Production Usage: ./push-images.sh --username myUserName --password myPassword --production true
+# IMPORTANT: this script is intended to be used during the Github Actions build steps (using secret credentials)
+# This script pushes existing images to Docker Hub
+# Development Usage: ./push-images.sh --username=myUserName --password=myPassword
+# Production Usage: ./push-images.sh --username=myUserName --password=myPassword --production=true
 
 GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 CYAN='\033[1;36m'
 NC='\033[0m' # No Color
 
-echo "==== push-images.sh script ===="
+echo $(date -u) "==== push-images.sh script ===="
 while [ $# -gt 0 ]; do
   case "$1" in
     --username=*)
@@ -28,15 +29,15 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-echo "Logging into PBBG.com Docker Hub"
+echo $(date -u) "Logging into PBBG.com Docker Hub"
 echo $password | docker login -u $username --password-stdin
 
 if [ -n "$production" ]; then
-  echo "${CYAN}Pushing production images to PBBG.com Docker Hub${NC}"
+  echo $(date -u) "${CYAN}Pushing production images to PBBG.com Docker Hub${NC}"
   docker-compose -f docker-compose.build-for-prod.yml push
 else
-  echo "${YELLOW}Pushing development images to PBBG.com Docker Hub${NC}"
+  echo $(date -u) "${YELLOW}Pushing development images to PBBG.com Docker Hub${NC}"
   docker-compose push
 fi
 
-echo "${GREEN}Successfully pushed images to Docker Hub.${NC}"
+echo $(date -u) "${GREEN}Successfully pushed images to Docker Hub.${NC}"

--- a/scripts/setup-docker.sh
+++ b/scripts/setup-docker.sh
@@ -5,11 +5,11 @@ set -e
 GREEN='\033[1;32m'
 NC='\033[0m' # No Color
 
-echo "==== setup-docker.sh script ===="
-echo "${GREEN}Updating apt-get...${NC}"
+echo $(date -u) "==== setup-docker.sh script ===="
+echo $(date -u) "${GREEN}Updating apt-get...${NC}"
 sudo apt-get update
 
-echo "${GREEN}Enabling docker repository over https...${NC}"
+echo $(date -u) "${GREEN}Enabling docker repository over https...${NC}"
 sudo apt-get install \
     apt-transport-https \
     ca-certificates \
@@ -17,41 +17,41 @@ sudo apt-get install \
     gnupg-agent \
     software-properties-common
 
-echo "${GREEN}Adding Docker's official GPG key...${NC}"
+echo $(date -u) "${GREEN}Adding Docker's official GPG key...${NC}"
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 
-echo "${GREEN}Verify the key with fingerprint matching 0EBFCD88...${NC}"
+echo $(date -u) "${GREEN}Verify the key with fingerprint matching 0EBFCD88...${NC}"
 if sudo apt-key fingerprint 0EBFCD88 | grep -q "Docker Release"; then
-  echo "${GREEN}Fingerprint confirmed!${NC}"
+  echo $(date -u) "${GREEN}Fingerprint confirmed!${NC}"
 fi
 
-echo "${GREEN}Setup stable docker repository...${NC}"
+echo $(date -u) "${GREEN}Setup stable docker repository...${NC}"
 sudo add-apt-repository \
    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
    $(lsb_release -cs) \
    stable"
 
-echo "${GREEN}Installing docker engine from stable repository...${NC}"
+echo $(date -u) "${GREEN}Installing docker engine from stable repository...${NC}"
 sudo apt-get install docker-ce docker-ce-cli containerd.io
 
-echo "${GREEN}Setting docker to start automatically on server boot...${NC}"
+echo $(date -u) "${GREEN}Setting docker to start automatically on server boot...${NC}"
 sudo systemctl enable --now docker
 
-echo "${GREEN}Verifying docker installation...${NC}"
+echo $(date -u) "${GREEN}Verifying docker installation...${NC}"
 if sudo docker run hello-world | grep -q "Hello from Docker!"; then
-  echo "${GREEN}Installation successful!${NC}"
+  echo $(date -u) "${GREEN}Installation successful!${NC}"
 fi
 
-echo "${GREEN}Installing Docker-Compose...${NC}"
+echo $(date -u) "${GREEN}Installing Docker-Compose...${NC}"
 sudo curl -L "https://github.com/docker/compose/releases/download/1.28.5/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 
-echo "${GREEN}Applying executable permissions to the Docker-Compose binary...${NC}"
+echo $(date -u) "${GREEN}Applying executable permissions to the Docker-Compose binary...${NC}"
 sudo chmod +x /usr/local/bin/docker-compose
 
-echo "${GREEN}Adding bash completion to bash for docker-compose...${NC}"
+echo $(date -u) "${GREEN}Adding bash completion to bash for docker-compose...${NC}"
 sudo curl -L https://raw.githubusercontent.com/docker/compose/1.28.5/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
 
-echo "${GREEN}Test Docker-Compose installation...${NC}"
+echo $(date -u) "${GREEN}Test Docker-Compose installation...${NC}"
 if sudo docker-compose --version | grep -q "docker-compose version"; then
-  echo "${GREEN}Installation successful!${NC}"
+  echo $(date -u) "${GREEN}Installation successful!${NC}"
 fi

--- a/scripts/update-portainer-stack.sh
+++ b/scripts/update-portainer-stack.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+set -e
+# This script updates the docker-compose.yml for the docker stack in Portainer
+# Using a docker container from:  https://hub.docker.com/r/greenled/portainer-stack-utils/
+# Development Usage: ./update-portainer-stack.sh --portainer_username=myUserName --portainer_password=myPassword
+# Production Usage: ./update-portainer-stack.sh --portainer_username=myUserName --portainer_password=myPassword --production=true
+
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[1;36m'
+NC='\033[0m' # No Color
+
+echo $(date -u) "==== update-portainer-stack.sh script ===="
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --portainer_username=*)
+      portainer_username="${1#*=}"
+      ;;
+    --portainer_password=*)
+      portainer_password="${1#*=}"
+      ;;
+    --production=*)
+      production="${1#*=}"
+      ;;
+    *)
+      printf "* Error: Invalid argument.*\n"
+      exit 1
+  esac
+  shift
+done
+
+if [ -n "$production" ]; then
+  COMPOSE_FILE='docker-compose.production.yml'
+  URL="http://143.110.157.206:9000"
+  STACK_NAME='pbbgproduction'
+  OUTPUT_COLOR=${CYAN}
+else
+  COMPOSE_FILE='docker-compose.development.yml'
+  URL="http://143.110.157.206:9000"
+  STACK_NAME='pbbgdevelopment'
+  OUTPUT_COLOR=${YELLOW}
+fi
+
+echo $(date -u) "Removing ${OUTPUT_COLOR}${STACK_NAME}${NC} Portainer stack via API..."
+docker run -e ACTION="undeploy" -e PORTAINER_USER=${portainer_username} -e PORTAINER_PASSWORD=${portainer_password} -e PORTAINER_URL=${URL} -e PORTAINER_STACK_NAME=${STACK_NAME} greenled/portainer-stack-utils psu
+echo $(date -u) "${GREEN}Successfully removed ${OUTPUT_COLOR}${STACK_NAME}${NC}${GREEN} stack.${NC}"
+
+echo $(date -u) "Creating ${OUTPUT_COLOR}${STACK_NAME}${NC} Portainer stack via API..."
+docker run -v $(pwd)/${COMPOSE_FILE}:/${COMPOSE_FILE} -e ACTION="deploy" -e PORTAINER_USER=${portainer_username} -e PORTAINER_PASSWORD=${portainer_password} -e PORTAINER_URL=${URL} -e PORTAINER_STACK_NAME=${STACK_NAME} -e DOCKER_COMPOSE_FILE=${COMPOSE_FILE} greenled/portainer-stack-utils psu
+echo $(date -u) "${GREEN}Successfully created ${OUTPUT_COLOR}${STACK_NAME}${NC}${GREEN} stack.${NC}"


### PR DESCRIPTION
The big change here is the update-portainer-stack shell script which will remove and recreate the docker stack in the DO droplets after the Github Actions build is complete and new images are pushed to Docker Hub.  This seems to actually handle grabbing the just-moments-ago new images, so Watchtower may not even be needed.

Github Repo Secrets have been added to keep passwords hidden.  Also, the script will handle both Dev and Prod environments once (once Prod exists).

Also added timestamps to other shell script output.